### PR TITLE
Reset timeleft to 10 when pressing 'New game' button

### DIFF
--- a/script.js
+++ b/script.js
@@ -17,7 +17,7 @@ let options = {
 //count
 let winCount = 0;
 let count = 0;
-
+let timeleft = 10;
 let chosenWord = "";
 
 //Display option buttons
@@ -77,6 +77,7 @@ const generateWord = (optionValue) => {
 const initializer = () => {
     winCount = 0;
     count = 0;
+    timeleft = 10;
 
     //Initially erase all content and hide letteres and new game button
     userInputSection.innerHTML = "";
@@ -220,9 +221,9 @@ const drawMan = (count) => {
     }
 };
 
-ProgressCountdown(10, "pageBeginCountdownText");
+ProgressCountdown("pageBeginCountdownText");
 
-function ProgressCountdown(timeleft, text) {
+function ProgressCountdown(text) {
     return new Promise((resolve, reject) => {
         var countdownTimer = setInterval(() => {
             timeleft--;


### PR DESCRIPTION
The bug: The 'New game' button does not reset the countdown timer. 
Why: When the 'New game' button is pressed we call the function `initializer()`, but we do not update how much time is left in this function. 

To fix this I have removed the `timeleft` parameter from the `ProgressCountdown()` function. Instead of passing it in to the function we create a variable `let timeleft = 10;` and use that in `ProgressCountdown()`. 

I added a line in the `initializer()` function, which sets `timeleft` to 10. Then when the 'New game' button is pressed and calls `initializer()` we reset the timer to 10. 

This is a minor fix - if the timer runs to 0 the timer will no longer restart. We can fix that later. 